### PR TITLE
[cookidoo-mcp] Add Docker configuration

### DIFF
--- a/.opencode/skills/github-workflow/SKILL.md
+++ b/.opencode/skills/github-workflow/SKILL.md
@@ -22,6 +22,105 @@ Dieses Monorepo enthält 4 Services. Jedes Issue MUSS mit dem entsprechenden Ser
 - `service:assistant-mcp` - cookidoo-assistant-mcp Service
 - `service:api` - cookidoo-assistant-api Service
 
+## Issue Bearbeitungs-Workflow
+
+Wenn ein Issue bearbeitet wird (z.B. `implementiere #22`), folge diesem Ablauf:
+
+### 1. Issue-Status auf "In Progress" setzen
+```bash
+gh issue edit ISSUE_NUMBER --add-project "cookidoo-assistant" --repo TheRealKoller/cookidoo-assistant
+# Status via gh project item-edit ändern (siehe unten)
+```
+
+### 2. Feature-Branch von main erstellen
+```bash
+git checkout main
+git pull origin main
+git checkout -b ISSUE_NUMBER-short-description
+git push -u origin ISSUE_NUMBER-short-description
+
+# Beispiel
+git checkout main
+git pull origin main
+git checkout -b 22-docker-config
+git push -u origin 22-docker-config
+```
+
+### 3. Branch im Issue verlinken
+```bash
+gh issue comment ISSUE_NUMBER --body "🔧 Branch erstellt: \`ISSUE_NUMBER-short-description\`" --repo TheRealKoller/cookidoo-assistant
+```
+
+### 4. Implementierung durchführen
+- Code schreiben
+- Commits machen
+
+### 5. Qualitätsprüfung durchführen
+```bash
+# Je nach Service entsprechende Skripte ausführen:
+
+# cookidoo-mcp (Python)
+cd cookidoo-mcp
+black . --check
+ruff check .
+mypy .
+pytest
+
+# TypeScript Services
+cd cookidoo-assistant-{shared,mcp,api}
+npm run lint
+npm run format:check
+npm run type-check
+npm run test
+
+# Gefundene Issues beheben und erneut prüfen
+```
+
+### 6. Pull Request erstellen
+```bash
+gh pr create \
+  --repo TheRealKoller/cookidoo-assistant \
+  --base main \
+  --head ISSUE_NUMBER-short-description \
+  --title "[Service] Short description" \
+  --body "$(cat <<'EOF'
+Closes #ISSUE_NUMBER
+
+## Services Affected
+- service:X
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+- [x] Lint passed
+- [x] Format passed
+- [x] Type check passed
+- [x] Tests passed
+EOF
+)"
+```
+
+### 7. PR im Issue verlinken
+```bash
+PR_URL=$(gh pr view --json url -q .url)
+gh issue comment ISSUE_NUMBER --body "🔀 Pull Request: $PR_URL" --repo TheRealKoller/cookidoo-assistant
+```
+
+### 8. Issue-Status auf "In Review" setzen
+```bash
+# Status via gh project item-edit ändern (siehe unten)
+```
+
+### 9. User informieren
+```
+✅ Pull Request erstellt: [PR-URL]
+
+Bitte review das PR. Wenn alles passt:
+`gh pr merge [PR-NUMBER] --repo TheRealKoller/cookidoo-assistant --squash --delete-branch`
+```
+
 ## Workflow-Schritte
 
 ### 1. Issue-Management

--- a/cookidoo-mcp/.env.example
+++ b/cookidoo-mcp/.env.example
@@ -9,5 +9,5 @@ PORT=3000
 # Logging
 LOG_LEVEL=info
 
-# Node Environment
-NODE_ENV=development
+# Python Environment
+PYTHONUNBUFFERED=1

--- a/cookidoo-mcp/Dockerfile
+++ b/cookidoo-mcp/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY src/ ./src/
+COPY .env.example .env
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD python -c "import requests; requests.get('http://localhost:${PORT:-3000}/health', timeout=5)"
+
+EXPOSE 3000
+
+CMD ["python", "-m", "src.server"]

--- a/cookidoo-mcp/docker-compose.yml
+++ b/cookidoo-mcp/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  cookidoo-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3000}:3000"
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:3000/health', timeout=5)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s

--- a/cookidoo-mcp/pyproject.toml
+++ b/cookidoo-mcp/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "cookidoo-mcp"
+version = "0.1.0"
+requires-python = ">=3.12"
+
+[tool.black]
+line-length = 100
+target-version = ['py312']
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false

--- a/cookidoo-mcp/requirements.txt
+++ b/cookidoo-mcp/requirements.txt
@@ -1,0 +1,9 @@
+# Core dependencies
+cookidoo-api==0.17.0
+fastapi
+uvicorn
+python-dotenv
+requests
+
+# MCP SDK
+mcp

--- a/cookidoo-mcp/src/__init__.py
+++ b/cookidoo-mcp/src/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/cookidoo-mcp/src/server.py
+++ b/cookidoo-mcp/src/server.py
@@ -1,0 +1,18 @@
+import os
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+@app.get("/health")
+async def health_check():
+    return JSONResponse({
+        "status": "ok",
+        "service": "cookidoo-mcp",
+        "version": "0.1.0"
+    })
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 3000))
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
Closes #22

## Services Affected
- service:cookidoo-mcp

## Changes
- Added Dockerfile with Python 3.12-slim base
- Added docker-compose.yml with health check on port 3000
- Added requirements.txt with cookidoo-api, fastapi, uvicorn, mcp
- Added FastAPI health endpoint at /health
- Updated .env.example for Python environment
- Added pyproject.toml for Python tooling config
- Updated github-workflow skill with standardized issue workflow

## Testing
- [x] Docker build successful
- [x] Container starts without errors
- [x] Health endpoint returns 200 OK
- [x] All changes committed and pushed

## Notes
- Requires Python 3.12+ (cookidoo-api dependency)
- Version pins removed from requirements.txt to resolve mcp/fastapi starlette conflict
- Health check endpoint ready for future MCP implementation