### PR TITLE
[cookidoo-mcp] Implement search_recipes MCP tool

### DIFF
--- a/cookidoo-mcp/docs/tools/search_recipes.md
+++ b/cookidoo-mcp/docs/tools/search_recipes.md
@@ -1,0 +1,192 @@
+# search_recipes MCP Tool
+
+Search for recipes on Cookidoo with support for text queries, ingredient filters, dietary restrictions, and more.
+
+## Endpoint
+
+`POST /tools/search_recipes`
+
+## Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `query` | string | No | - | Freetext search query (searches in title and description) |
+| `ingredients` | string[] | No | [] | List of ingredients that must be present in the recipe |
+| `diet` | string | No | - | Dietary filter: `omnivor`, `vegetarian`, `vegan`, or `pescetarian` |
+| `exclude_ingredients` | string[] | No | [] | Ingredients that must NOT be in the recipe |
+| `max_results` | number | No | 20 | Maximum number of results (1-100) |
+| `offset` | number | No | 0 | Pagination offset (0-based) |
+
+## Response
+
+Returns `SearchRecipesResponse` object:
+
+```json
+{
+  "recipes": [
+    {
+      "id": "r123456",
+      "title": "Tomato Soup",
+      "description": "A delicious creamy tomato soup",
+      "image_url": "https://cookidoo.com/images/...",
+      "cooking_time": 30,
+      "difficulty": "easy"
+    }
+  ],
+  "total": 42,
+  "offset": 0,
+  "limit": 20
+}
+```
+
+## Fields
+
+### SearchRecipesResponse
+- `recipes[]` - Array of matching recipes
+- `total` - Total number of matching recipes (before pagination)
+- `offset` - Current pagination offset
+- `limit` - Maximum results per page
+
+### SearchRecipeResult
+- `id` - Cookidoo recipe ID
+- `title` - Recipe name
+- `description` - Recipe description (optional)
+- `image_url` - Recipe image URL (optional)
+- `cooking_time` - Total cooking time in minutes (optional)
+- `difficulty` - Difficulty level: easy, medium, hard (optional)
+
+## Filters
+
+### Query Filter
+Searches for text in both recipe title and description (case-insensitive):
+```json
+{"query": "pasta"}
+```
+
+### Ingredient Filter
+All specified ingredients must be present in the recipe:
+```json
+{"ingredients": ["tomato", "basil", "garlic"]}
+```
+
+### Diet Filter
+Filters recipes based on dietary restrictions:
+- `vegan` - No meat, fish, dairy, or eggs
+- `vegetarian` - No meat or fish (dairy and eggs allowed)
+- `pescetarian` - No meat (fish, dairy, and eggs allowed)
+- `omnivor` - No restrictions
+
+```json
+{"diet": "vegan"}
+```
+
+### Exclude Ingredients
+Filters out recipes containing specified ingredients:
+```json
+{"exclude_ingredients": ["nuts", "gluten"]}
+```
+
+### Pagination
+Use `offset` and `max_results` for pagination:
+```json
+{
+  "max_results": 10,
+  "offset": 0
+}
+```
+
+## Errors
+
+- `400` - Invalid parameters (e.g., invalid diet, max_results out of range)
+- `500` - Internal server error
+
+## Examples
+
+### Basic Search
+Search for recipes containing "soup":
+```bash
+curl -X POST http://localhost:3000/tools/search_recipes \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "soup"}'
+```
+
+### Search with Ingredients
+Find recipes with tomatoes and basil:
+```bash
+curl -X POST http://localhost:3000/tools/search_recipes \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ingredients": ["tomato", "basil"]
+  }'
+```
+
+### Vegan Recipes
+Find vegan recipes:
+```bash
+curl -X POST http://localhost:3000/tools/search_recipes \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "diet": "vegan"
+  }'
+```
+
+### Complex Search
+Search for vegetarian pasta recipes without nuts:
+```bash
+curl -X POST http://localhost:3000/tools/search_recipes \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "pasta",
+    "diet": "vegetarian",
+    "exclude_ingredients": ["nuts"],
+    "max_results": 10
+  }'
+```
+
+### Pagination
+Get second page of results (items 20-39):
+```bash
+curl -X POST http://localhost:3000/tools/search_recipes \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "max_results": 20,
+    "offset": 20
+  }'
+```
+
+## Implementation Notes
+
+**Current Limitations:**
+- The cookidoo-api library does not expose a native search endpoint
+- Current implementation uses managed collections as a data source
+- This may not cover all recipes in the Cookidoo database
+- Performance may be slower for large result sets due to client-side filtering
+
+**Future Improvements:**
+- Reverse engineer and implement direct Cookidoo search API endpoint
+- Add caching for collection data
+- Implement full-text search indexing
+- Add more sophisticated ingredient matching
+
+**Filter Behavior:**
+- All filters are combined with AND logic (all must match)
+- Text search is case-insensitive
+- Ingredient matching is partial (e.g., "tomato" matches "cherry tomatoes")
+- Diet filters use keyword-based detection and may have false positives/negatives
+
+## Tips
+
+1. **Start Broad**: Begin with fewer filters and refine as needed
+2. **Pagination**: Use reasonable `max_results` values (10-50) for better performance
+3. **Ingredient Names**: Use common ingredient names (e.g., "tomato" not "tomatoes")
+4. **Diet Filter**: Combine with ingredient filters for more accurate results
+5. **Total Count**: Use the `total` field to implement pagination UI
+
+## Related Tools
+
+- `get_recipe_details` - Get full details for a specific recipe by ID

--- a/cookidoo-mcp/src/server.py
+++ b/cookidoo-mcp/src/server.py
@@ -7,6 +7,8 @@ from src.logging_config import logger
 from src.middleware import auth_middleware
 from src.cookidoo_client import cookidoo_connection
 from src.tools.recipe_details import get_recipe_details
+from src.tools.search_recipes import search_recipes
+from src.tools.types import SearchRecipesRequest
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -59,6 +61,26 @@ async def handle_get_recipe_details(recipe_id: str):
         return JSONResponse({"error": str(e)}, status_code=404)
     except Exception as e:
         logger.error(f"Error in get_recipe_details: {e}", exc_info=True)
+        return JSONResponse({"error": "Internal error"}, status_code=500)
+
+
+@app.post("/tools/search_recipes")
+async def handle_search_recipes(request: SearchRecipesRequest):
+    """Search for recipes with various filters"""
+    try:
+        results = await search_recipes(
+            query=request.query,
+            ingredients=request.ingredients,
+            diet=request.diet,
+            exclude_ingredients=request.exclude_ingredients,
+            max_results=request.max_results,
+            offset=request.offset,
+        )
+        return JSONResponse(results.model_dump())
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    except Exception as e:
+        logger.error(f"Error in search_recipes: {e}", exc_info=True)
         return JSONResponse({"error": "Internal error"}, status_code=500)
 
 if __name__ == "__main__":

--- a/cookidoo-mcp/src/tools/search_recipes.py
+++ b/cookidoo-mcp/src/tools/search_recipes.py
@@ -1,0 +1,242 @@
+"""Search recipes tool implementation."""
+
+import re
+from typing import Optional
+
+from cookidoo_api import CookidooShoppingRecipeDetails
+
+from ..cookidoo_client import cookidoo_connection
+from .types import SearchRecipeResult, SearchRecipesResponse
+
+
+async def search_recipes(
+    query: Optional[str] = None,
+    ingredients: Optional[list[str]] = None,
+    diet: Optional[str] = None,
+    exclude_ingredients: Optional[list[str]] = None,
+    max_results: int = 20,
+    offset: int = 0,
+) -> SearchRecipesResponse:
+    """Search for recipes with various filters.
+    
+    NOTE: Current implementation uses managed collections as the cookidoo-api 
+    library does not expose a native search endpoint. This provides basic 
+    functionality but may not cover all recipes in the Cookidoo database.
+    
+    Future improvement: Reverse engineer and implement direct search API endpoint.
+    
+    Args:
+        query: Freetext search query (searches in title and description)
+        ingredients: List of ingredients to search for
+        diet: Dietary filter (omnivor, vegetarian, vegan, pescetarian)
+        exclude_ingredients: Ingredients to exclude
+        max_results: Maximum number of results to return (1-100)
+        offset: Pagination offset
+        
+    Returns:
+        SearchRecipesResponse with matching recipes and metadata
+        
+    Raises:
+        ValueError: If parameters are invalid
+        RuntimeError: If Cookidoo client is not connected
+    """
+    # Validate parameters
+    if max_results < 1 or max_results > 100:
+        raise ValueError("max_results must be between 1 and 100")
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if diet and diet not in ["omnivor", "vegetarian", "vegan", "pescetarian"]:
+        raise ValueError(f"Invalid diet filter: {diet}")
+    
+    # Get client
+    client = cookidoo_connection.client
+    
+    # Normalize inputs for case-insensitive matching
+    ingredients_lower = [ing.lower() for ing in (ingredients or [])]
+    exclude_ingredients_lower = [ing.lower() for ing in (exclude_ingredients or [])]
+    query_lower = query.lower() if query else None
+    
+    # Collect recipes from managed collections
+    # We'll fetch multiple pages to get a good sample size
+    all_recipe_ids: set[str] = set()
+    collections_to_fetch = 5  # Fetch first 5 pages of collections
+    
+    for page in range(collections_to_fetch):
+        try:
+            collections = await client.get_managed_collections(page=page)
+            if not collections:
+                break
+                
+            for collection in collections:
+                for chapter in collection.chapters:
+                    for recipe in chapter.recipes:
+                        all_recipe_ids.add(recipe.id)
+        except Exception:
+            # If we fail to get a page, just continue with what we have
+            break
+    
+    # Now filter recipes based on search criteria
+    matching_recipes: list[SearchRecipeResult] = []
+    
+    for recipe_id in all_recipe_ids:
+        try:
+            # Get full recipe details for filtering
+            details = await client.get_recipe_details(recipe_id)
+            
+            # Apply filters
+            if not _matches_filters(
+                details,
+                query_lower,
+                ingredients_lower,
+                exclude_ingredients_lower,
+                diet,
+            ):
+                continue
+            
+            # Convert to search result
+            search_result = _convert_to_search_result(details)
+            matching_recipes.append(search_result)
+            
+        except Exception:
+            # Skip recipes that fail to load
+            continue
+    
+    # Sort by title for consistent ordering
+    matching_recipes.sort(key=lambda r: r.title)
+    
+    # Apply pagination
+    total = len(matching_recipes)
+    paginated_recipes = matching_recipes[offset : offset + max_results]
+    
+    return SearchRecipesResponse(
+        recipes=paginated_recipes,
+        total=total,
+        offset=offset,
+        limit=max_results,
+    )
+
+
+def _matches_filters(
+    details: CookidooShoppingRecipeDetails,
+    query: Optional[str],
+    ingredients: list[str],
+    exclude_ingredients: list[str],
+    diet: Optional[str],
+) -> bool:
+    """Check if recipe matches all filters."""
+    
+    # Query filter (searches in title and description)
+    if query:
+        title_lower = details.name.lower()
+        desc_lower = (details.description or "").lower()
+        
+        if query not in title_lower and query not in desc_lower:
+            return False
+    
+    # Get ingredient names from recipe
+    recipe_ingredient_names = [
+        ing.name.lower() 
+        for ing in details.ingredients
+    ]
+    
+    # Ingredients filter (all must be present)
+    if ingredients:
+        for required_ing in ingredients:
+            if not any(required_ing in rec_ing for rec_ing in recipe_ingredient_names):
+                return False
+    
+    # Exclude ingredients filter (none must be present)
+    if exclude_ingredients:
+        for excluded_ing in exclude_ingredients:
+            if any(excluded_ing in rec_ing for rec_ing in recipe_ingredient_names):
+                return False
+    
+    # Diet filter
+    if diet:
+        if not _matches_diet(recipe_ingredient_names, diet):
+            return False
+    
+    return True
+
+
+def _matches_diet(ingredient_names: list[str], diet: str) -> bool:
+    """Check if recipe matches dietary restrictions.
+    
+    This is a basic implementation using common ingredient patterns.
+    Could be improved with a more comprehensive ingredient database.
+    """
+    # Common meat/fish/animal product keywords
+    meat_keywords = [
+        "beef", "pork", "chicken", "turkey", "lamb", "duck", "meat",
+        "bacon", "ham", "sausage", "salami", "prosciutto", "steak",
+    ]
+    fish_keywords = [
+        "fish", "salmon", "tuna", "cod", "trout", "shrimp", "prawn",
+        "crab", "lobster", "seafood", "anchovy", "sardine",
+    ]
+    dairy_keywords = [
+        "milk", "cream", "cheese", "butter", "yogurt", "yoghurt",
+    ]
+    egg_keywords = ["egg"]
+    
+    has_meat = any(
+        any(keyword in ing for keyword in meat_keywords)
+        for ing in ingredient_names
+    )
+    has_fish = any(
+        any(keyword in ing for keyword in fish_keywords)
+        for ing in ingredient_names
+    )
+    has_dairy = any(
+        any(keyword in ing for keyword in dairy_keywords)
+        for ing in ingredient_names
+    )
+    has_eggs = any(
+        any(keyword in ing for keyword in egg_keywords)
+        for ing in ingredient_names
+    )
+    
+    if diet == "vegan":
+        return not (has_meat or has_fish or has_dairy or has_eggs)
+    elif diet == "vegetarian":
+        return not (has_meat or has_fish)
+    elif diet == "pescetarian":
+        return not has_meat
+    elif diet == "omnivor":
+        # Omnivores can eat anything
+        return True
+    
+    return True
+
+
+def _convert_to_search_result(
+    details: CookidooShoppingRecipeDetails,
+) -> SearchRecipeResult:
+    """Convert full recipe details to search result."""
+    # Extract image URL from image data if available
+    image_url = None
+    if hasattr(details, 'image') and details.image:
+        # The image might be a URL or a data structure
+        if isinstance(details.image, str):
+            image_url = details.image
+        elif hasattr(details.image, 'url'):
+            image_url = details.image.url
+    
+    # Get cooking time in minutes
+    cooking_time = None
+    if hasattr(details, 'total_time') and details.total_time:
+        cooking_time = details.total_time // 60  # Convert seconds to minutes
+    
+    # Extract difficulty if available
+    difficulty = None
+    if hasattr(details, 'difficulty'):
+        difficulty = details.difficulty
+    
+    return SearchRecipeResult(
+        id=details.id,
+        title=details.name,
+        description=details.description,
+        image_url=image_url,
+        cooking_time=cooking_time,
+        difficulty=difficulty,
+    )

--- a/cookidoo-mcp/src/tools/types.py
+++ b/cookidoo-mcp/src/tools/types.py
@@ -27,3 +27,31 @@ class RecipeDetails(BaseModel):
     instructions: list[RecipeStep] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
     equipment: list[str] = Field(default_factory=list)
+
+
+class SearchRecipeResult(BaseModel):
+    """Simplified recipe result for search operations."""
+    id: str
+    title: str
+    description: Optional[str] = None
+    image_url: Optional[str] = None
+    cooking_time: Optional[int] = None  # minutes
+    difficulty: Optional[str] = None
+
+
+class SearchRecipesRequest(BaseModel):
+    """Request parameters for recipe search."""
+    query: Optional[str] = None
+    ingredients: list[str] = Field(default_factory=list)
+    diet: Optional[str] = None  # omnivor, vegetarian, vegan, pescetarian
+    exclude_ingredients: list[str] = Field(default_factory=list)
+    max_results: int = Field(default=20, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)
+
+
+class SearchRecipesResponse(BaseModel):
+    """Response containing search results and metadata."""
+    recipes: list[SearchRecipeResult] = Field(default_factory=list)
+    total: int
+    offset: int
+    limit: int

--- a/cookidoo-mcp/tests/test_search_recipes.py
+++ b/cookidoo-mcp/tests/test_search_recipes.py
@@ -1,0 +1,350 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.tools.search_recipes import search_recipes, _matches_filters, _matches_diet
+from src.tools.types import SearchRecipesResponse, SearchRecipeResult
+from src.cookidoo_client import cookidoo_connection
+from cookidoo_api.types import CookidooIngredient
+
+
+@pytest.fixture
+def mock_collection():
+    """Mock collection with recipes."""
+    collection = MagicMock()
+    collection.chapters = [
+        MagicMock(
+            recipes=[
+                MagicMock(id="r001", name="Pasta Carbonara", total_time=1800),
+                MagicMock(id="r002", name="Vegetable Soup", total_time=2400),
+            ]
+        )
+    ]
+    return collection
+
+
+@pytest.fixture
+def mock_recipe_details_meat():
+    """Mock recipe with meat."""
+    from cookidoo_api.types import CookidooIngredient
+    
+    recipe = MagicMock()
+    recipe.id = "r001"
+    recipe.name = "Pasta Carbonara"
+    recipe.description = "Classic Italian pasta with bacon"
+    recipe.image = "http://example.com/image1.jpg"
+    recipe.total_time = 1800
+    recipe.difficulty = "medium"
+    recipe.ingredients = [
+        CookidooIngredient(id="1", name="Pasta", description="400 g"),
+        CookidooIngredient(id="2", name="Bacon", description="200 g"),
+        CookidooIngredient(id="3", name="Eggs", description="4 pcs"),
+        CookidooIngredient(id="4", name="Parmesan", description="100 g"),
+    ]
+    return recipe
+
+
+@pytest.fixture
+def mock_recipe_details_vegan():
+    """Mock vegan recipe."""
+    from cookidoo_api.types import CookidooIngredient
+    
+    recipe = MagicMock()
+    recipe.id = "r002"
+    recipe.name = "Vegetable Soup"
+    recipe.description = "Healthy vegetable soup"
+    recipe.image = None
+    recipe.total_time = 2400
+    recipe.difficulty = "easy"
+    recipe.ingredients = [
+        CookidooIngredient(id="5", name="Carrots", description="300 g"),
+        CookidooIngredient(id="6", name="Tomatoes", description="500 g"),
+        CookidooIngredient(id="7", name="Onions", description="2 pcs"),
+    ]
+    return recipe
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_basic(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test basic search without filters."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes()
+    
+    assert isinstance(result, SearchRecipesResponse)
+    assert result.total == 2
+    assert len(result.recipes) == 2
+    assert result.recipes[0].title == "Pasta Carbonara"
+    assert result.recipes[1].title == "Vegetable Soup"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_with_query(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test search with text query."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(query="pasta")
+    
+    assert result.total == 1
+    assert len(result.recipes) == 1
+    assert result.recipes[0].title == "Pasta Carbonara"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_with_ingredients(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test search with ingredient filter."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(ingredients=["bacon"])
+    
+    assert result.total == 1
+    assert len(result.recipes) == 1
+    assert result.recipes[0].title == "Pasta Carbonara"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_exclude_ingredients(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test search with ingredient exclusion."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(exclude_ingredients=["bacon"])
+    
+    assert result.total == 1
+    assert len(result.recipes) == 1
+    assert result.recipes[0].title == "Vegetable Soup"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_diet_vegan(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test search with vegan diet filter."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(diet="vegan")
+    
+    assert result.total == 1
+    assert len(result.recipes) == 1
+    assert result.recipes[0].title == "Vegetable Soup"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_diet_vegetarian(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test search with vegetarian diet filter."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(diet="vegetarian")
+    
+    # Only vegan recipe should match (no meat/fish)
+    assert result.total == 1
+    assert result.recipes[0].title == "Vegetable Soup"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_pagination(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test pagination."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(max_results=1, offset=0)
+    
+    assert result.total == 2
+    assert len(result.recipes) == 1
+    assert result.offset == 0
+    assert result.limit == 1
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_pagination_offset(mock_collection, mock_recipe_details_meat, mock_recipe_details_vegan):
+    """Test pagination with offset."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(
+        side_effect=[mock_recipe_details_meat, mock_recipe_details_vegan]
+    )
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes(max_results=1, offset=1)
+    
+    assert result.total == 2
+    assert len(result.recipes) == 1
+    assert result.recipes[0].title == "Vegetable Soup"
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_invalid_max_results():
+    """Test validation of max_results."""
+    with pytest.raises(ValueError, match="max_results must be between 1 and 100"):
+        await search_recipes(max_results=0)
+    
+    with pytest.raises(ValueError, match="max_results must be between 1 and 100"):
+        await search_recipes(max_results=101)
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_invalid_offset():
+    """Test validation of offset."""
+    with pytest.raises(ValueError, match="offset must be non-negative"):
+        await search_recipes(offset=-1)
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_invalid_diet():
+    """Test validation of diet parameter."""
+    with pytest.raises(ValueError, match="Invalid diet filter"):
+        await search_recipes(diet="invalid_diet")
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_empty_collections():
+    """Test search with no collections."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[])
+    cookidoo_connection._client = mock_client
+    
+    result = await search_recipes()
+    
+    assert result.total == 0
+    assert len(result.recipes) == 0
+
+
+@pytest.mark.asyncio
+async def test_search_recipes_api_error_handling(mock_collection):
+    """Test handling of API errors."""
+    mock_client = AsyncMock()
+    mock_client.get_managed_collections = AsyncMock(return_value=[mock_collection])
+    mock_client.get_recipe_details = AsyncMock(side_effect=Exception("API Error"))
+    cookidoo_connection._client = mock_client
+    
+    # Should not raise, just skip failed recipes
+    result = await search_recipes()
+    
+    assert result.total == 0
+    assert len(result.recipes) == 0
+
+
+def test_matches_diet_vegan():
+    """Test vegan diet matching."""
+    # Vegan recipe
+    assert _matches_diet(["tomatoes", "carrots", "onions"], "vegan")
+    
+    # Not vegan (has meat)
+    assert not _matches_diet(["chicken", "tomatoes"], "vegan")
+    
+    # Not vegan (has dairy)
+    assert not _matches_diet(["milk", "tomatoes"], "vegan")
+    
+    # Not vegan (has eggs)
+    assert not _matches_diet(["eggs", "flour"], "vegan")
+
+
+def test_matches_diet_vegetarian():
+    """Test vegetarian diet matching."""
+    # Vegetarian (no meat/fish)
+    assert _matches_diet(["eggs", "cheese", "tomatoes"], "vegetarian")
+    
+    # Not vegetarian (has meat)
+    assert not _matches_diet(["beef", "potatoes"], "vegetarian")
+    
+    # Not vegetarian (has fish)
+    assert not _matches_diet(["salmon", "rice"], "vegetarian")
+
+
+def test_matches_diet_pescetarian():
+    """Test pescetarian diet matching."""
+    # Pescetarian (fish ok, no meat)
+    assert _matches_diet(["salmon", "vegetables"], "pescetarian")
+    
+    # Not pescetarian (has meat)
+    assert not _matches_diet(["chicken", "fish"], "pescetarian")
+
+
+def test_matches_diet_omnivor():
+    """Test omnivore diet (allows everything)."""
+    assert _matches_diet(["chicken", "beef", "pork"], "omnivor")
+    assert _matches_diet(["vegetables"], "omnivor")
+
+
+def test_matches_filters_query():
+    """Test query filtering."""
+    recipe = MagicMock()
+    recipe.name = "Pasta Carbonara"
+    recipe.description = "Italian classic"
+    recipe.ingredients = []
+    
+    # Match in title
+    assert _matches_filters(recipe, "pasta", [], [], None)
+    
+    # Match in description
+    assert _matches_filters(recipe, "italian", [], [], None)
+    
+    # No match
+    assert not _matches_filters(recipe, "pizza", [], [], None)
+
+
+def test_matches_filters_ingredients():
+    """Test ingredient filtering."""
+    from cookidoo_api.types import CookidooIngredient
+    
+    recipe = MagicMock()
+    recipe.name = "Test Recipe"
+    recipe.description = None
+    recipe.ingredients = [
+        CookidooIngredient(id="1", name="Tomatoes", description="500 g"),
+        CookidooIngredient(id="2", name="Cheese", description="100 g"),
+    ]
+    
+    # Has required ingredient
+    assert _matches_filters(recipe, None, ["tomatoes"], [], None)
+    
+    # Missing required ingredient
+    assert not _matches_filters(recipe, None, ["bacon"], [], None)
+
+
+def test_matches_filters_exclude_ingredients():
+    """Test ingredient exclusion."""
+    from cookidoo_api.types import CookidooIngredient
+    
+    recipe = MagicMock()
+    recipe.name = "Test Recipe"
+    recipe.description = None
+    recipe.ingredients = [
+        CookidooIngredient(id="1", name="Tomatoes", description="500 g"),
+        CookidooIngredient(id="2", name="Cheese", description="100 g"),
+    ]
+    
+    # Does not have excluded ingredient
+    assert _matches_filters(recipe, None, [], ["bacon"], None)
+    
+    # Has excluded ingredient
+    assert not _matches_filters(recipe, None, [], ["cheese"], None)

--- a/cookidoo-mcp/tests/test_search_recipes_integration.py
+++ b/cookidoo-mcp/tests/test_search_recipes_integration.py
@@ -1,0 +1,229 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_search_results():
+    """Mock search results."""
+    return {
+        "recipes": [
+            {
+                "id": "r001",
+                "title": "Pasta Carbonara",
+                "description": "Italian classic",
+                "image_url": "http://example.com/image1.jpg",
+                "cooking_time": 30,
+                "difficulty": "medium",
+            },
+            {
+                "id": "r002",
+                "title": "Vegetable Soup",
+                "description": "Healthy soup",
+                "image_url": None,
+                "cooking_time": 40,
+                "difficulty": "easy",
+            },
+        ],
+        "total": 2,
+        "offset": 0,
+        "limit": 20,
+    }
+
+
+def test_search_recipes_endpoint_basic(client, mock_search_results):
+    """Test search_recipes endpoint with basic request."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(model_dump=lambda: mock_search_results)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["recipes"]) == 2
+        assert data["recipes"][0]["title"] == "Pasta Carbonara"
+
+
+def test_search_recipes_endpoint_with_query(client, mock_search_results):
+    """Test search_recipes endpoint with query parameter."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(
+            model_dump=lambda: {
+                "recipes": [mock_search_results["recipes"][0]],
+                "total": 1,
+                "offset": 0,
+                "limit": 20,
+            }
+        )
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"query": "pasta"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["recipes"][0]["title"] == "Pasta Carbonara"
+
+
+def test_search_recipes_endpoint_with_ingredients(client, mock_search_results):
+    """Test search_recipes endpoint with ingredient filter."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(model_dump=lambda: mock_search_results)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"ingredients": ["tomato", "basil"]},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "recipes" in data
+
+
+def test_search_recipes_endpoint_with_diet(client, mock_search_results):
+    """Test search_recipes endpoint with diet filter."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(model_dump=lambda: mock_search_results)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"diet": "vegan"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "recipes" in data
+
+
+def test_search_recipes_endpoint_with_exclude(client, mock_search_results):
+    """Test search_recipes endpoint with ingredient exclusion."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(model_dump=lambda: mock_search_results)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"exclude_ingredients": ["nuts"]},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "recipes" in data
+
+
+def test_search_recipes_endpoint_pagination(client, mock_search_results):
+    """Test search_recipes endpoint with pagination."""
+    with patch("src.server.search_recipes") as mock_search:
+        paginated = mock_search_results.copy()
+        paginated["recipes"] = [mock_search_results["recipes"][0]]
+        paginated["offset"] = 0
+        paginated["limit"] = 1
+        mock_search.return_value = MagicMock(model_dump=lambda: paginated)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"max_results": 1, "offset": 0},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["recipes"]) == 1
+        assert data["offset"] == 0
+        assert data["limit"] == 1
+
+
+def test_search_recipes_endpoint_combined_filters(client, mock_search_results):
+    """Test search_recipes endpoint with multiple filters."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.return_value = MagicMock(model_dump=lambda: mock_search_results)
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={
+                "query": "pasta",
+                "ingredients": ["tomato"],
+                "diet": "vegetarian",
+                "exclude_ingredients": ["meat"],
+                "max_results": 10,
+            },
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "recipes" in data
+
+
+def test_search_recipes_endpoint_invalid_max_results(client):
+    """Test search_recipes endpoint with invalid max_results."""
+    # Pydantic validation will catch this and return 422
+    response = client.post(
+        "/tools/search_recipes",
+        json={"max_results": 200},
+        headers={"X-API-Key": "test_api_key"},
+    )
+    
+    # 422 is returned by Pydantic validation
+    assert response.status_code == 422
+
+
+def test_search_recipes_endpoint_invalid_diet(client):
+    """Test search_recipes endpoint with invalid diet."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.side_effect = ValueError("Invalid diet filter")
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={"diet": "invalid"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 400
+        assert "error" in response.json()
+
+
+def test_search_recipes_endpoint_internal_error(client):
+    """Test search_recipes endpoint with internal error."""
+    with patch("src.server.search_recipes") as mock_search:
+        mock_search.side_effect = Exception("Internal error")
+        
+        response = client.post(
+            "/tools/search_recipes",
+            json={},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 500
+        assert "error" in response.json()
+
+
+def test_search_recipes_endpoint_no_auth(client):
+    """Test search_recipes endpoint without authentication."""
+    response = client.post(
+        "/tools/search_recipes",
+        json={},
+    )
+    
+    assert response.status_code == 401
+
+
+def test_search_recipes_endpoint_invalid_auth(client):
+    """Test search_recipes endpoint with invalid API key."""
+    response = client.post(
+        "/tools/search_recipes",
+        json={},
+        headers={"X-API-Key": "wrong_key"},
+    )
+    
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implements the `search_recipes` MCP tool as specified in #24 with full support for:
- Freetext search in recipe titles and descriptions
- Ingredient-based filtering (required ingredients)
- Dietary restrictions (vegan, vegetarian, pescetarian, omnivor)
- Ingredient exclusion filters
- Pagination (max_results, offset)

## Changes

### Core Implementation
- **types.py**: Added `SearchRecipeResult`, `SearchRecipesRequest`, `SearchRecipesResponse` models
- **search_recipes.py**: Complete search tool implementation with filtering logic
- **server.py**: New `/tools/search_recipes` endpoint with validation and error handling

### Testing
- **test_search_recipes.py**: 20 unit tests covering all filters, validation, and edge cases
- **test_search_recipes_integration.py**: 12 integration tests for API endpoint

### Documentation
- **search_recipes.md**: Comprehensive docs with API reference, examples, and usage tips

## Test Results

All 48 tests pass (including 32 new tests for search functionality):
```
48 passed in 0.31s
```

## Implementation Notes

The cookidoo-api library does not expose a native search endpoint. Current implementation uses `managed_collections` as data source with client-side filtering. This provides good functionality but could be improved in the future by reverse-engineering the Cookidoo search API.

## Closes

Resolves #24