### PR TITLE
[cookidoo-mcp] Implement get_recipe_nutrition MCP tool

### DIFF
--- a/cookidoo-mcp/docs/tools/get_recipe_nutrition.md
+++ b/cookidoo-mcp/docs/tools/get_recipe_nutrition.md
@@ -1,0 +1,220 @@
+# get_recipe_nutrition MCP Tool
+
+Retrieve nutritional information for Cookidoo recipes.
+
+## Endpoint
+
+`POST /tools/get_recipe_nutrition`
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `recipe_id` | string | Yes | Cookidoo recipe ID |
+
+## Response
+
+Returns `RecipeNutrition` object:
+
+```json
+{
+  "recipe_id": "r123456",
+  "serving_size": 4,
+  "calories": 450.0,
+  "protein": 25.5,
+  "carbohydrates": 50.0,
+  "fat": 15.0,
+  "fiber": 8.0,
+  "sugar": 12.0,
+  "sodium": 500.0,
+  "saturated_fat": 3.5,
+  "nutrients": [
+    {
+      "value": 450.0,
+      "unit": "kcal",
+      "type": "energy"
+    },
+    {
+      "value": 25.5,
+      "unit": "g",
+      "type": "protein"
+    }
+  ]
+}
+```
+
+## Fields
+
+### RecipeNutrition
+- `recipe_id` - Cookidoo recipe ID
+- `serving_size` - Number of servings (default: 1 if not specified)
+- `calories` - Total calories per serving in kcal (optional)
+- `protein` - Protein in grams per serving (optional)
+- `carbohydrates` - Carbohydrates in grams per serving (optional)
+- `fat` - Total fat in grams per serving (optional)
+- `fiber` - Dietary fiber in grams per serving (optional)
+- `sugar` - Sugar in grams per serving (optional)
+- `sodium` - Sodium in milligrams per serving (optional)
+- `saturated_fat` - Saturated fat in grams per serving (optional)
+- `nutrients[]` - Complete list of all available nutrients
+
+### NutrientInfo
+- `value` - Nutrient value (numeric)
+- `unit` - Unit of measurement (e.g., "g", "mg", "kcal")
+- `type` - Nutrient type/name (e.g., "protein", "energy")
+
+## Behavior
+
+### Energy Conversion
+- Energy values in kJ are automatically converted to kcal (1 kcal = 4.184 kJ)
+- Both kcal and kJ values are supported
+
+### Sodium Conversion
+- Sodium values in grams are automatically converted to milligrams
+- Both g and mg values are supported
+
+### Missing Data
+- If a recipe has no nutrition data, all nutrient fields will be `null`
+- The `nutrients` array will be empty
+- `serving_size` defaults to 1 if not provided
+
+### Per-Serving Values
+- All values are calculated per serving
+- Use `serving_size` to calculate total recipe nutrition
+
+## Errors
+
+- `404` - Recipe not found, invalid ID, or failed to retrieve nutrition data
+- `500` - Internal server error
+
+## Examples
+
+### Basic Request
+Get nutrition information for a recipe:
+```bash
+curl -X POST http://localhost:3000/tools/get_recipe_nutrition \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  --data-urlencode "recipe_id=r123456"
+```
+
+### With Query Parameters
+```bash
+curl -X POST "http://localhost:3000/tools/get_recipe_nutrition?recipe_id=r123456" \
+  -H "X-API-Key: your-api-key"
+```
+
+### Response with Complete Data
+```json
+{
+  "recipe_id": "r123456",
+  "serving_size": 4,
+  "calories": 450.0,
+  "protein": 25.5,
+  "carbohydrates": 50.0,
+  "fat": 15.0,
+  "fiber": 8.0,
+  "sugar": 12.0,
+  "sodium": 500.0,
+  "saturated_fat": 3.5,
+  "nutrients": [
+    {"value": 450.0, "unit": "kcal", "type": "energy"},
+    {"value": 25.5, "unit": "g", "type": "protein"},
+    {"value": 50.0, "unit": "g", "type": "carbohydrate"},
+    {"value": 15.0, "unit": "g", "type": "fat"},
+    {"value": 8.0, "unit": "g", "type": "fiber"},
+    {"value": 12.0, "unit": "g", "type": "sugar"},
+    {"value": 500.0, "unit": "mg", "type": "sodium"},
+    {"value": 3.5, "unit": "g", "type": "saturated fat"}
+  ]
+}
+```
+
+### Response without Nutrition Data
+```json
+{
+  "recipe_id": "r999999",
+  "serving_size": 2,
+  "calories": null,
+  "protein": null,
+  "carbohydrates": null,
+  "fat": null,
+  "fiber": null,
+  "sugar": null,
+  "sodium": null,
+  "saturated_fat": null,
+  "nutrients": []
+}
+```
+
+### Response with Partial Data
+Some recipes may have incomplete nutrition information:
+```json
+{
+  "recipe_id": "r555555",
+  "serving_size": 2,
+  "calories": 300.0,
+  "protein": 20.0,
+  "carbohydrates": null,
+  "fat": null,
+  "fiber": null,
+  "sugar": null,
+  "sodium": null,
+  "saturated_fat": null,
+  "nutrients": [
+    {"value": 300.0, "unit": "kcal", "type": "energy"},
+    {"value": 20.0, "unit": "g", "type": "protein"}
+  ]
+}
+```
+
+## Use Cases
+
+### Meal Planning
+Calculate total daily nutrition by summing values across multiple recipes:
+```python
+# Get nutrition for multiple recipes
+breakfast = await get_recipe_nutrition("r111111")
+lunch = await get_recipe_nutrition("r222222")
+dinner = await get_recipe_nutrition("r333333")
+
+# Calculate daily totals
+total_calories = (breakfast.calories or 0) + (lunch.calories or 0) + (dinner.calories or 0)
+total_protein = (breakfast.protein or 0) + (lunch.protein or 0) + (dinner.protein or 0)
+```
+
+### Dietary Goals
+Check if recipe meets dietary requirements:
+```python
+nutrition = await get_recipe_nutrition("r123456")
+
+# High protein, low carb check
+if nutrition.protein and nutrition.carbohydrates:
+    protein_ratio = nutrition.protein / nutrition.carbohydrates
+    if protein_ratio > 0.5:
+        print("High protein recipe!")
+```
+
+### Scaling Recipes
+Calculate nutrition for different serving sizes:
+```python
+nutrition = await get_recipe_nutrition("r123456")
+desired_servings = 8
+
+# Scale up from 4 servings to 8
+scale_factor = desired_servings / nutrition.serving_size
+scaled_calories = (nutrition.calories or 0) * scale_factor
+```
+
+## Notes
+
+- Recipe IDs can be obtained from `search_recipes` or `get_recipe_details`
+- Not all recipes have complete nutrition data
+- Always check for `null` values before performing calculations
+- Nutrition values are extracted from `nutrition_groups` in the Cookidoo API
+- The `nutrients` array contains all raw nutrition data from the API
+
+## Related Tools
+
+- `get_recipe_details` - Get full recipe details including ingredients
+- `search_recipes` - Search for recipes by criteria

--- a/cookidoo-mcp/src/server.py
+++ b/cookidoo-mcp/src/server.py
@@ -8,6 +8,7 @@ from src.middleware import auth_middleware
 from src.cookidoo_client import cookidoo_connection
 from src.tools.recipe_details import get_recipe_details
 from src.tools.search_recipes import search_recipes
+from src.tools.recipe_nutrition import get_recipe_nutrition
 from src.tools.types import SearchRecipesRequest
 
 @asynccontextmanager
@@ -81,6 +82,19 @@ async def handle_search_recipes(request: SearchRecipesRequest):
         return JSONResponse({"error": str(e)}, status_code=400)
     except Exception as e:
         logger.error(f"Error in search_recipes: {e}", exc_info=True)
+        return JSONResponse({"error": "Internal error"}, status_code=500)
+
+
+@app.post("/tools/get_recipe_nutrition")
+async def handle_get_recipe_nutrition(recipe_id: str):
+    """Get nutritional information for a recipe"""
+    try:
+        nutrition = await get_recipe_nutrition(recipe_id)
+        return JSONResponse(nutrition.model_dump())
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=404)
+    except Exception as e:
+        logger.error(f"Error in get_recipe_nutrition: {e}", exc_info=True)
         return JSONResponse({"error": "Internal error"}, status_code=500)
 
 if __name__ == "__main__":

--- a/cookidoo-mcp/src/tools/recipe_nutrition.py
+++ b/cookidoo-mcp/src/tools/recipe_nutrition.py
@@ -1,0 +1,112 @@
+"""Get recipe nutrition information tool implementation."""
+
+from typing import Optional
+
+from ..cookidoo_client import cookidoo_connection
+from .types import RecipeNutrition, NutrientInfo
+
+
+async def get_recipe_nutrition(recipe_id: str) -> RecipeNutrition:
+    """Get nutritional information for a recipe.
+    
+    Args:
+        recipe_id: Cookidoo recipe ID
+        
+    Returns:
+        RecipeNutrition object with nutritional data per serving
+        
+    Raises:
+        ValueError: If recipe_id is invalid or recipe not found
+        RuntimeError: If Cookidoo client is not connected
+    """
+    if not recipe_id:
+        raise ValueError("recipe_id is required")
+    
+    try:
+        client = cookidoo_connection.client
+        details = await client.get_recipe_details(recipe_id)
+        
+        # Initialize nutrition data
+        serving_size = details.serving_size or 1
+        
+        # Extract all nutrients from nutrition_groups
+        nutrients = []
+        calories = None
+        protein = None
+        carbohydrates = None
+        fat = None
+        fiber = None
+        sugar = None
+        sodium = None
+        saturated_fat = None
+        
+        # Parse nutrition_groups
+        for nutrition_group in details.nutrition_groups:
+            for recipe_nutrition in nutrition_group.recipe_nutritions:
+                for nutrition in recipe_nutrition.nutritions:
+                    nutrient_type = nutrition.type.lower()
+                    value = nutrition.number
+                    unit = nutrition.unittype
+                    
+                    # Store full nutrient info
+                    nutrients.append(NutrientInfo(
+                        value=value,
+                        unit=unit,
+                        type=nutrition.type
+                    ))
+                    
+                    # Map to common fields based on nutrient type
+                    if nutrient_type == "energy" or nutrient_type == "calories":
+                        # Energy is usually in kcal or kJ
+                        if unit.lower() in ["kcal", "cal"]:
+                            calories = value
+                        elif unit.lower() == "kj":
+                            # Convert kJ to kcal (1 kcal = 4.184 kJ)
+                            calories = value / 4.184
+                    
+                    elif nutrient_type == "protein" or "protein" in nutrient_type:
+                        if unit.lower() == "g":
+                            protein = value
+                    
+                    elif nutrient_type == "carbohydrate" or "carbohydrate" in nutrient_type:
+                        if unit.lower() == "g":
+                            carbohydrates = value
+                    
+                    elif nutrient_type == "fat" or nutrient_type == "total fat":
+                        if unit.lower() == "g":
+                            fat = value
+                    
+                    elif "saturated" in nutrient_type and "fat" in nutrient_type:
+                        if unit.lower() == "g":
+                            saturated_fat = value
+                    
+                    elif nutrient_type == "fiber" or "fiber" in nutrient_type or "fibre" in nutrient_type:
+                        if unit.lower() == "g":
+                            fiber = value
+                    
+                    elif nutrient_type == "sugar" or "sugar" in nutrient_type:
+                        if unit.lower() == "g":
+                            sugar = value
+                    
+                    elif nutrient_type == "sodium" or "sodium" in nutrient_type:
+                        if unit.lower() == "mg":
+                            sodium = value
+                        elif unit.lower() == "g":
+                            sodium = value * 1000  # Convert g to mg
+        
+        return RecipeNutrition(
+            recipe_id=recipe_id,
+            serving_size=serving_size,
+            calories=calories,
+            protein=protein,
+            carbohydrates=carbohydrates,
+            fat=fat,
+            fiber=fiber,
+            sugar=sugar,
+            sodium=sodium,
+            saturated_fat=saturated_fat,
+            nutrients=nutrients,
+        )
+        
+    except Exception as e:
+        raise ValueError(f"Failed to get recipe nutrition: {str(e)}")

--- a/cookidoo-mcp/src/tools/types.py
+++ b/cookidoo-mcp/src/tools/types.py
@@ -55,3 +55,25 @@ class SearchRecipesResponse(BaseModel):
     total: int
     offset: int
     limit: int
+
+
+class NutrientInfo(BaseModel):
+    """Single nutrient information."""
+    value: float
+    unit: str
+    type: str  # e.g., "energy", "protein", "carbohydrate", etc.
+
+
+class RecipeNutrition(BaseModel):
+    """Nutritional information for a recipe."""
+    recipe_id: str
+    serving_size: int
+    calories: Optional[float] = None  # kcal per serving
+    protein: Optional[float] = None  # grams per serving
+    carbohydrates: Optional[float] = None  # grams per serving
+    fat: Optional[float] = None  # grams per serving
+    fiber: Optional[float] = None  # grams per serving
+    sugar: Optional[float] = None  # grams per serving
+    sodium: Optional[float] = None  # mg per serving
+    saturated_fat: Optional[float] = None  # grams per serving
+    nutrients: list[NutrientInfo] = Field(default_factory=list)  # All available nutrients

--- a/cookidoo-mcp/tests/test_recipe_nutrition.py
+++ b/cookidoo-mcp/tests/test_recipe_nutrition.py
@@ -1,0 +1,266 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from src.tools.recipe_nutrition import get_recipe_nutrition
+from src.tools.types import RecipeNutrition
+from src.cookidoo_client import cookidoo_connection
+
+
+@pytest.fixture
+def mock_recipe_with_nutrition():
+    """Mock recipe with complete nutrition data."""
+    mock_nutrition = MagicMock()
+    mock_nutrition.type = "energy"
+    mock_nutrition.number = 450.0
+    mock_nutrition.unittype = "kcal"
+    
+    mock_protein = MagicMock()
+    mock_protein.type = "protein"
+    mock_protein.number = 25.5
+    mock_protein.unittype = "g"
+    
+    mock_carbs = MagicMock()
+    mock_carbs.type = "carbohydrate"
+    mock_carbs.number = 50.0
+    mock_carbs.unittype = "g"
+    
+    mock_fat = MagicMock()
+    mock_fat.type = "fat"
+    mock_fat.number = 15.0
+    mock_fat.unittype = "g"
+    
+    mock_fiber = MagicMock()
+    mock_fiber.type = "fiber"
+    mock_fiber.number = 8.0
+    mock_fiber.unittype = "g"
+    
+    mock_sugar = MagicMock()
+    mock_sugar.type = "sugar"
+    mock_sugar.number = 12.0
+    mock_sugar.unittype = "g"
+    
+    mock_sodium = MagicMock()
+    mock_sodium.type = "sodium"
+    mock_sodium.number = 500.0
+    mock_sodium.unittype = "mg"
+    
+    mock_saturated = MagicMock()
+    mock_saturated.type = "saturated fat"
+    mock_saturated.number = 3.5
+    mock_saturated.unittype = "g"
+    
+    mock_recipe_nutrition = MagicMock()
+    mock_recipe_nutrition.nutritions = [
+        mock_nutrition,
+        mock_protein,
+        mock_carbs,
+        mock_fat,
+        mock_fiber,
+        mock_sugar,
+        mock_sodium,
+        mock_saturated,
+    ]
+    
+    mock_nutrition_group = MagicMock()
+    mock_nutrition_group.recipe_nutritions = [mock_recipe_nutrition]
+    
+    recipe = MagicMock()
+    recipe.id = "r123456"
+    recipe.serving_size = 4
+    recipe.nutrition_groups = [mock_nutrition_group]
+    
+    return recipe
+
+
+@pytest.fixture
+def mock_recipe_with_kj_energy():
+    """Mock recipe with energy in kJ instead of kcal."""
+    mock_nutrition = MagicMock()
+    mock_nutrition.type = "energy"
+    mock_nutrition.number = 1884.0  # 450 kcal * 4.184
+    mock_nutrition.unittype = "kJ"
+    
+    mock_recipe_nutrition = MagicMock()
+    mock_recipe_nutrition.nutritions = [mock_nutrition]
+    
+    mock_nutrition_group = MagicMock()
+    mock_nutrition_group.recipe_nutritions = [mock_recipe_nutrition]
+    
+    recipe = MagicMock()
+    recipe.id = "r123456"
+    recipe.serving_size = 4
+    recipe.nutrition_groups = [mock_nutrition_group]
+    
+    return recipe
+
+
+@pytest.fixture
+def mock_recipe_without_nutrition():
+    """Mock recipe without nutrition data."""
+    recipe = MagicMock()
+    recipe.id = "r999999"
+    recipe.serving_size = 2
+    recipe.nutrition_groups = []
+    
+    return recipe
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_success(mock_recipe_with_nutrition):
+    """Test successful nutrition retrieval."""
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=mock_recipe_with_nutrition)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r123456")
+    
+    assert isinstance(result, RecipeNutrition)
+    assert result.recipe_id == "r123456"
+    assert result.serving_size == 4
+    assert result.calories == 450.0
+    assert result.protein == 25.5
+    assert result.carbohydrates == 50.0
+    assert result.fat == 15.0
+    assert result.fiber == 8.0
+    assert result.sugar == 12.0
+    assert result.sodium == 500.0
+    assert result.saturated_fat == 3.5
+    assert len(result.nutrients) == 8
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_kj_conversion(mock_recipe_with_kj_energy):
+    """Test conversion of kJ to kcal."""
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=mock_recipe_with_kj_energy)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r123456")
+    
+    assert result.calories is not None
+    # 1884 kJ / 4.184 ≈ 450 kcal
+    assert abs(result.calories - 450.0) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_without_data(mock_recipe_without_nutrition):
+    """Test recipe without nutrition data."""
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=mock_recipe_without_nutrition)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r999999")
+    
+    assert isinstance(result, RecipeNutrition)
+    assert result.recipe_id == "r999999"
+    assert result.serving_size == 2
+    assert result.calories is None
+    assert result.protein is None
+    assert result.carbohydrates is None
+    assert result.fat is None
+    assert len(result.nutrients) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_missing_recipe_id():
+    """Test validation of recipe_id."""
+    with pytest.raises(ValueError, match="recipe_id is required"):
+        await get_recipe_nutrition("")
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_api_error():
+    """Test handling of API errors."""
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(side_effect=Exception("API Error"))
+    cookidoo_connection._client = mock_client
+    
+    with pytest.raises(ValueError, match="Failed to get recipe nutrition"):
+        await get_recipe_nutrition("invalid_id")
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_partial_data():
+    """Test recipe with partial nutrition data."""
+    # Only energy and protein
+    mock_energy = MagicMock()
+    mock_energy.type = "energy"
+    mock_energy.number = 300.0
+    mock_energy.unittype = "kcal"
+    
+    mock_protein = MagicMock()
+    mock_protein.type = "protein"
+    mock_protein.number = 20.0
+    mock_protein.unittype = "g"
+    
+    mock_recipe_nutrition = MagicMock()
+    mock_recipe_nutrition.nutritions = [mock_energy, mock_protein]
+    
+    mock_nutrition_group = MagicMock()
+    mock_nutrition_group.recipe_nutritions = [mock_recipe_nutrition]
+    
+    recipe = MagicMock()
+    recipe.id = "r555555"
+    recipe.serving_size = 2
+    recipe.nutrition_groups = [mock_nutrition_group]
+    
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=recipe)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r555555")
+    
+    assert result.calories == 300.0
+    assert result.protein == 20.0
+    assert result.carbohydrates is None
+    assert result.fat is None
+    assert len(result.nutrients) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_sodium_gram_conversion():
+    """Test conversion of sodium from g to mg."""
+    mock_sodium = MagicMock()
+    mock_sodium.type = "sodium"
+    mock_sodium.number = 1.5  # grams
+    mock_sodium.unittype = "g"
+    
+    mock_recipe_nutrition = MagicMock()
+    mock_recipe_nutrition.nutritions = [mock_sodium]
+    
+    mock_nutrition_group = MagicMock()
+    mock_nutrition_group.recipe_nutritions = [mock_recipe_nutrition]
+    
+    recipe = MagicMock()
+    recipe.id = "r777777"
+    recipe.serving_size = 1
+    recipe.nutrition_groups = [mock_nutrition_group]
+    
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=recipe)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r777777")
+    
+    # 1.5g = 1500mg
+    assert result.sodium == 1500.0
+
+
+@pytest.mark.asyncio
+async def test_get_recipe_nutrition_default_serving_size():
+    """Test default serving size when not specified."""
+    mock_nutrition_group = MagicMock()
+    mock_nutrition_group.recipe_nutritions = []
+    
+    recipe = MagicMock()
+    recipe.id = "r888888"
+    recipe.serving_size = None  # No serving size
+    recipe.nutrition_groups = [mock_nutrition_group]
+    
+    mock_client = AsyncMock()
+    mock_client.get_recipe_details = AsyncMock(return_value=recipe)
+    cookidoo_connection._client = mock_client
+    
+    result = await get_recipe_nutrition("r888888")
+    
+    # Should default to 1
+    assert result.serving_size == 1

--- a/cookidoo-mcp/tests/test_recipe_nutrition_integration.py
+++ b/cookidoo-mcp/tests/test_recipe_nutrition_integration.py
@@ -1,0 +1,192 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_nutrition_result():
+    """Mock nutrition result."""
+    return {
+        "recipe_id": "r123456",
+        "serving_size": 4,
+        "calories": 450.0,
+        "protein": 25.5,
+        "carbohydrates": 50.0,
+        "fat": 15.0,
+        "fiber": 8.0,
+        "sugar": 12.0,
+        "sodium": 500.0,
+        "saturated_fat": 3.5,
+        "nutrients": [
+            {"value": 450.0, "unit": "kcal", "type": "energy"},
+            {"value": 25.5, "unit": "g", "type": "protein"},
+            {"value": 50.0, "unit": "g", "type": "carbohydrate"},
+            {"value": 15.0, "unit": "g", "type": "fat"},
+            {"value": 8.0, "unit": "g", "type": "fiber"},
+            {"value": 12.0, "unit": "g", "type": "sugar"},
+            {"value": 500.0, "unit": "mg", "type": "sodium"},
+            {"value": 3.5, "unit": "g", "type": "saturated fat"},
+        ],
+    }
+
+
+def test_get_recipe_nutrition_endpoint_success(client, mock_nutrition_result):
+    """Test get_recipe_nutrition endpoint with successful request."""
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.return_value = MagicMock(model_dump=lambda: mock_nutrition_result)
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": "r123456"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recipe_id"] == "r123456"
+        assert data["serving_size"] == 4
+        assert data["calories"] == 450.0
+        assert data["protein"] == 25.5
+        assert data["carbohydrates"] == 50.0
+        assert data["fat"] == 15.0
+        assert data["fiber"] == 8.0
+        assert data["sugar"] == 12.0
+        assert data["sodium"] == 500.0
+        assert data["saturated_fat"] == 3.5
+        assert len(data["nutrients"]) == 8
+
+
+def test_get_recipe_nutrition_endpoint_no_nutrition(client):
+    """Test endpoint with recipe that has no nutrition data."""
+    mock_result = {
+        "recipe_id": "r999999",
+        "serving_size": 2,
+        "calories": None,
+        "protein": None,
+        "carbohydrates": None,
+        "fat": None,
+        "fiber": None,
+        "sugar": None,
+        "sodium": None,
+        "saturated_fat": None,
+        "nutrients": [],
+    }
+    
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.return_value = MagicMock(model_dump=lambda: mock_result)
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": "r999999"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recipe_id"] == "r999999"
+        assert data["calories"] is None
+        assert data["protein"] is None
+        assert len(data["nutrients"]) == 0
+
+
+def test_get_recipe_nutrition_endpoint_invalid_id(client):
+    """Test endpoint with invalid recipe ID."""
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.side_effect = ValueError("recipe_id is required")
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": ""},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 404
+        assert "error" in response.json()
+
+
+def test_get_recipe_nutrition_endpoint_recipe_not_found(client):
+    """Test endpoint with non-existent recipe."""
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.side_effect = ValueError("Failed to get recipe nutrition")
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": "invalid_recipe"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 404
+        assert "error" in response.json()
+
+
+def test_get_recipe_nutrition_endpoint_internal_error(client):
+    """Test endpoint with internal error."""
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.side_effect = Exception("Internal error")
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": "r123456"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 500
+        assert "error" in response.json()
+
+
+def test_get_recipe_nutrition_endpoint_no_auth(client):
+    """Test endpoint without authentication."""
+    response = client.post(
+        "/tools/get_recipe_nutrition",
+        params={"recipe_id": "r123456"},
+    )
+    
+    assert response.status_code == 401
+
+
+def test_get_recipe_nutrition_endpoint_invalid_auth(client):
+    """Test endpoint with invalid API key."""
+    response = client.post(
+        "/tools/get_recipe_nutrition",
+        params={"recipe_id": "r123456"},
+        headers={"X-API-Key": "wrong_key"},
+    )
+    
+    assert response.status_code == 401
+
+
+def test_get_recipe_nutrition_endpoint_partial_data(client):
+    """Test endpoint with partial nutrition data."""
+    mock_result = {
+        "recipe_id": "r555555",
+        "serving_size": 2,
+        "calories": 300.0,
+        "protein": 20.0,
+        "carbohydrates": None,
+        "fat": None,
+        "fiber": None,
+        "sugar": None,
+        "sodium": None,
+        "saturated_fat": None,
+        "nutrients": [
+            {"value": 300.0, "unit": "kcal", "type": "energy"},
+            {"value": 20.0, "unit": "g", "type": "protein"},
+        ],
+    }
+    
+    with patch("src.server.get_recipe_nutrition") as mock_get:
+        mock_get.return_value = MagicMock(model_dump=lambda: mock_result)
+        
+        response = client.post(
+            "/tools/get_recipe_nutrition",
+            params={"recipe_id": "r555555"},
+            headers={"X-API-Key": "test_api_key"},
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calories"] == 300.0
+        assert data["protein"] == 20.0
+        assert data["carbohydrates"] is None
+        assert data["fat"] is None
+        assert len(data["nutrients"]) == 2


### PR DESCRIPTION
## Summary
Implements Issue #25: New MCP tool to retrieve nutritional information from Cookidoo recipes.

## Changes
- **Types**: Added `NutrientInfo` and `RecipeNutrition` Pydantic models to `types.py`
- **Tool Implementation**: Created `recipe_nutrition.py` with nutrient parsing, unit conversions (kJ→kcal, g→mg for sodium)
- **API Endpoint**: Registered `/tools/get_recipe_nutrition` in `server.py`
- **Tests**: Added 8 unit tests + 8 integration tests (all passing)
- **Documentation**: Created comprehensive docs with examples and use cases

## Test Status
✅ All 64 tests passing (including 16 new tests for this feature)

```bash
cd cookidoo-mcp && pytest
```

## Key Features
- Extracts common nutrients (calories, protein, carbs, fat, fiber, sodium)
- Automatic unit conversions (kJ to kcal, sodium g to mg)
- Handles missing nutrition data gracefully
- Returns full nutrient list plus convenient dedicated fields

Resolves #25